### PR TITLE
Add README.md with instructions on how to build and develop the website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ _site
 .sass-cache
 .jekyll-metadata
 *.DS_Store
+
+*.code-workspace

--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# Modding Legacy Website
+
+Team Hollow Website built with Jekyll 3.8.5
+
+## Getting Started
+
+### Linux
+
+#### 1A) On Linux Install Ruby
+
+`sudo apt install ruby-full`
+
+#### 1B) On Windows
+
+You need to install [Ruby](https://rubyinstaller.org/). Make sure you get at least 2.6.X.
+
+#### 2) Clone the repo
+
+`git clone https://github.com/teamhollow/teamhollow.net.git`
+
+#### 3) Install bundler
+
+`gem install bundler`
+
+#### 4) Set up the workspace
+
+Navigate to the root of the directory and type: `bundle install`  
+This should install all the package needed for development.
+
+**Do not commit the modified Gemfile after this finishes** ***unless a gem needs to be updated!*** **Lachney will usually take care of that if that is the case.**
+
+## Compiling
+
+You can either build the website or serve it.
+
+### Build
+
+`bundle exec jekyll build`
+
+This will build the website and generate everything in the `_site` directory.
+
+`bundle exec jekyll serve`
+
+This will start a web server and serve the website on `http://127.0.0.1:4000`
+
+## Contributing
+
+Please make sure all your code is formatted properly and neatly and double check for any errors. Verify that your HTML elements work on multiple browsers. When you have verified everything, push your changes (or send a pull request) and the live website `teamhollow.net` will update from GitHub whenever possible.


### PR DESCRIPTION
Name entails. The README.md document I've added stems from other jekyll websites I've worked on and gives instructions on how to build and develop teamhollow.net so anyone can give contributions via pull requests if need be.

I was originally planning on bundling this with a few other commits looking at backend, but I don't know bootstrap to know what is going on, so this is all I've got for now. Looks good so far. Keep up the good work, fellas!